### PR TITLE
更改junit版本

### DIFF
--- a/com.qlc.test.redis-0.0.1-SNAPSHOT/pom.xml
+++ b/com.qlc.test.redis-0.0.1-SNAPSHOT/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.4</version>
+      <version>4.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
由于junit版本过低，下载下来的项目在用junit测试时会报空指针异常